### PR TITLE
feat(class): Allow `_created_in` attribute

### DIFF
--- a/3.2/itop_design.xsd
+++ b/3.2/itop_design.xsd
@@ -485,7 +485,7 @@
                                     </xs:choice>
                                     <xs:attribute name="id" type="xs:string" use="required" />
                                     <xs:attribute name="_delta" type="delta" use="optional" />
-                                    <xs:attribute name="_rename_from " type="xs:string" use="optional" />
+                                    <xs:attribute name="_rename_from" type="xs:string" use="optional" />
                                     <xs:attribute name="_created_in" type="xs:string" use="optional" />
                                 </xs:complexType>
                             </xs:element>
@@ -831,7 +831,7 @@
     <xs:complexType name="AttributeBase">
         <xs:attribute name="id" type="xs:string" use="required" />
         <xs:attribute name="_delta" type="delta" use="optional" />
-        <xs:attribute name="_rename_from " type="xs:string" use="optional" />
+        <xs:attribute name="_rename_from" type="xs:string" use="optional" />
     </xs:complexType>
 
     <xs:simpleType name="TrackingLevel">


### PR DESCRIPTION
Not documented in the reference, but used in the generated `datamodel-production.xml` file. I also use this in my extensions to know where a class was originally originated from.