### PR TITLE
add definition for method/arguments/argument

### DIFF
--- a/3.2/itop_design.xsd
+++ b/3.2/itop_design.xsd
@@ -348,9 +348,23 @@
                                                                 <xs:element name="access" type="xs:string" minOccurs="0" />
                                                                 <xs:element name="type" type="xs:string" minOccurs="0" />
                                                                 <xs:element name="arguments" minOccurs="0">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Use definition from https://www.itophub.io/wiki/page?id=latest:customization:form_prefill
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
                                                                     <xs:complexType>
-                                                                        <xs:sequence maxOccurs="unbounded">
-                                                                            <xs:element name="argument" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+                                                                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                                                            <xs:element name="argument">
+                                                                                <xs:complexType>
+                                                                                    <xs:all>
+                                                                                        <xs:element name="type" type="argumentTypeEnumeration" minOccurs="0" />
+                                                                                        <xs:element name="mandatory" minOccurs="0" />
+                                                                                    </xs:all>
+                                                                                    <xs:attribute name="id" type="xs:string" use="required" />
+                                                                                    <xs:attributeGroup ref="alteredNode" />
+                                                                                </xs:complexType>
+                                                                            </xs:element>
                                                                         </xs:sequence>
                                                                     </xs:complexType>
                                                                 </xs:element>
@@ -1200,6 +1214,17 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:attributeGroup>
+
+    <xs:simpleType name="argumentTypeEnumeration">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="attcode" />
+            <xs:enumeration value="class" />
+            <xs:enumeration value="current_stimulus_code" />
+            <xs:enumeration value="int" />
+            <xs:enumeration value="reference" />
+            <xs:enumeration value="string" />
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:simpleType name="trackingLevelEnumeration">
         <xs:restriction base="xs:string">


### PR DESCRIPTION
The explanation on this page seems to be wrong: https://www.itophub.io/wiki/page?id=latest:customization:xml_reference

I used the definition from this page: https://www.itophub.io/wiki/page?id=latest:customization:form_prefill