### PR TITLE
feat(AttributePassword): Add definition

### DIFF
--- a/3.2/itop_design.xsd
+++ b/3.2/itop_design.xsd
@@ -1968,6 +1968,14 @@
     </xs:complexType>
     <!-- ########################### /AttributeObjectKey ########################### -->
 
+    <!-- ########################### AttributePassword ########################### -->
+    <xs:complexType name="AttributePassword">
+        <xs:complexContent>
+            <xs:extension base="AttributeString" />
+        </xs:complexContent>
+    </xs:complexType>
+    <!-- ########################### /AttributePassword ########################### -->
+
     <!-- ########################### AttributePercentage ########################### -->
     <xs:complexType name="AttributePercentage">
         <xs:complexContent>


### PR DESCRIPTION
This is an undocumented attribute, defined in [attributedef.class.inc.php](https://github.com/Combodo/iTop/blob/f062f994f0a1e98e0842c33d4ec78acf0e323f74/core/attributedef.class.inc.php#L4219) and used in [tests](https://github.com/Combodo/iTop/blob/f062f994f0a1e98e0842c33d4ec78acf0e323f74/tests/php-unit-tests/unitary-tests/core/querybuilderexpressions/Delta/all-attributes.xml#L251-L256), [TeemIP](https://github.com/TeemIp/teemip-network-mgmt-extended/blob/88578a3ab73cb9e62505c7c26f9364a66a54a8f1/teemip-network-mgmt-extended/datamodel.teemip-network-mgmt-extended.xml#L2273-L2280), ...

I would like to start extracting all attribute definitions into a separate file and also make them hierarchical as in the PHP code.

```mermaid
classDiagram
    direction RL

    AttributeDefinition <|-- AttributeDBFieldVoid
    AttributeDBFieldVoid <|-- AttributeDBField
    AttributeDBField <|-- AttributeString

    class AttributeDefinition {
        + tracking_level
    }

    class AttributeDBFieldVoid {
        + sql
        + allowed_values
        + depends_on
    }

    class AttributeDBField {
        + default_value
        + is_null_allowed
    }

    class AttributeString {
        + validation_pattern
    }
```

Let me know what you think of this..