### PR TITLE
Allow _delta for filter elements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "extkey",
         "fileref",
         "finalclass",
+        "functionalci",
         "Hipska",
         "ITSM",
         "jointype",

--- a/3.2/itop_design.xsd
+++ b/3.2/itop_design.xsd
@@ -173,7 +173,7 @@
                                                                                     </xs:sequence>
                                                                                 </xs:complexType>
                                                                             </xs:element>
-                                                                            <xs:element name="filter" type="xs:string" minOccurs="0" />
+                                                                            <xs:element name="filter" type="alteredString" minOccurs="0" />
                                                                             <xs:element name="disabled" type="xs:boolean" minOccurs="0" />
                                                                             <xs:element name="is_blocking" type="xs:boolean" minOccurs="0" default="true" />
                                                                         </xs:all>
@@ -2034,7 +2034,7 @@
                     <xs:element name="is_null_allowed" type="xs:boolean" minOccurs="0" />
                     <xs:element name="on_target_delete" type="onTargetDeleteEnumeration" minOccurs="0" />
                     <xs:element name="target_class" type="xs:string" minOccurs="0" />
-                    <xs:element name="filter" type="xs:string" minOccurs="0" />
+                    <xs:element name="filter" type="alteredString" minOccurs="0" />
                     <xs:element name="dependencies" type="dependenciesType" minOccurs="0" />
                     <xs:element name="max_combo_length" type="xs:unsignedByte" minOccurs="0" />
                     <xs:element name="min_autocomplete_chars" type="xs:unsignedByte" minOccurs="0" />
@@ -2062,7 +2062,7 @@
                     <xs:element name="sql" type="xs:string" minOccurs="0" />
                     <xs:element name="is_null_allowed" type="xs:boolean" minOccurs="0" />
                     <xs:element name="on_target_delete" type="onTargetDeleteEnumeration" minOccurs="0" />
-                    <xs:element name="filter" type="xs:string" minOccurs="0" />
+                    <xs:element name="filter" type="alteredString" minOccurs="0" />
                     <xs:element name="dependencies" type="dependenciesType" minOccurs="0" />
                     <xs:element name="max_combo_length" type="xs:unsignedByte" minOccurs="0" />
                     <xs:element name="min_autocomplete_chars" type="xs:unsignedByte" minOccurs="0" />
@@ -2160,7 +2160,7 @@
             <xs:extension base="AttributeDefinition">
                 <xs:all>
                     <xs:element name="linked_class" type="xs:string" minOccurs="0" />
-                    <xs:element name="filter" type="xs:string" minOccurs="0" />
+                    <xs:element name="filter" type="alteredString" minOccurs="0" />
                     <xs:element name="ext_key_to_me" type="xs:string" minOccurs="0" />
                     <xs:element name="tracking_level" type="trackingLevelLinkedSetEnumeration" minOccurs="0" />
                     <xs:element name="edit_mode" type="editModeEnumeration" minOccurs="0" default="actions" />
@@ -2236,7 +2236,7 @@
                     </xs:element>
                     <xs:element name="with_php_constraint" type="xs:boolean" minOccurs="0" />
                     <xs:element name="with_php_computation" type="xs:boolean" minOccurs="0" />
-                    <xs:element name="filter" type="xs:string" minOccurs="0" />
+                    <xs:element name="filter" type="alteredString" minOccurs="0" />
                     <xs:element name="dependencies" type="dependenciesType" minOccurs="0" />
                 </xs:all>
             </xs:extension>

--- a/test/datamodel.must-validate.xml
+++ b/test/datamodel.must-validate.xml
@@ -398,10 +398,17 @@
                 </summary>
             </presentation>
         </class>
-        <class id="TestDeleteIfExists" _delta="define_if_not_exists">
+        <class id="TestDelta" _delta="define_if_not_exists">
             <properties>
                 <obsolescence _delta="delete_if_exists" />
             </properties>
+            <fields>
+                <field id="functionalci_id" xsi:type="AttributeExternalKey" _delta="must_exist">
+                    <!-- Issue: Tag filter of an AttributeExternalKey may be redefined
+                     https://github.com/rudnerbjoern/iTop-schema/issues/71 -->
+                    <filter _delta="redefine"><![CDATA[SELECT FunctionalCI WHERE finalclass IN ('NetworkDevice', 'Server', 'VirtualMachine')]]></filter>
+                </field>
+            </fields>
         </class>
         <class id="TestAttributes">
             <fields>


### PR DESCRIPTION
Use alteredString for all filter elements like:

```xml
            <fields>
                <field id="functionalci_id" xsi:type="AttributeExternalKey" _delta="must_exist">
                    <filter _delta="redefine"><![CDATA[SELECT FunctionalCI WHERE finalclass IN ('NetworkDevice', 'Server', 'VirtualMachine')]]></filter>
                </field>
            </fields>
```

Resolves: #71 
